### PR TITLE
fix(terminal_control): ensure terminal size for main menu

### DIFF
--- a/game/terminal_control.py
+++ b/game/terminal_control.py
@@ -1196,6 +1196,7 @@ class TerminalController:
                           menu_options: list[MenuOption],
                           cursor_index: int) -> int:
         """Display the menu options for the player"""
+        self.ensure_right_terminal_size()
         MAIN_MENU_HEIGHT: int = self.game_height
         MAIN_MENU_WIDTH: int = self.game_width
         


### PR DESCRIPTION
- Adds call to `ensure_right_terminal_size()` to `display_main_menu()`

- At the moment, this could cause a badly resized  terminal to not actually show the correct error text, even thought it's there as expected  by the call to  the `ensure____` function.
  - I opened a separate issue about this: [link](https://github.com/Vaiterius/Traditional-Roguelike/issues/6)